### PR TITLE
Check nil client before closing

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -50,9 +50,11 @@ func (g *Gateway) Dial(ctx context.Context, n, addr string) (net.Conn, error) {
 }
 
 func (g *Gateway) Close() error {
-	if err := g.c.Close(); err != nil {
-		_ = g.d.Close()
-		return err
+	if g.c != nil {
+		if err := g.c.Close(); err != nil {
+			_ = g.d.Close()
+			return err
+		}
 	}
 	return g.d.Close()
 }


### PR DESCRIPTION
## Summary
- Check the SSH client for nil in Gateway.Close before calling Close
- Ensure the dialer is always closed regardless of client state

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898b929aab48324a85585c04529deb1