### PR TITLE
Rename dailer to dialer and update references

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -43,7 +43,7 @@ type dialer interface {
 	Close() error
 }
 
-func newDailer(
+func newDialer(
 	keyFiles []KeyFile,
 	gatewayStr string, // user@addr:port
 	gatewayProxyCommand string,

--- a/gateway.go
+++ b/gateway.go
@@ -16,7 +16,7 @@ func NewGateway(
 	gatewayStr string, // user@addr:port
 	gatewayProxyCommand string,
 ) (*Gateway, error) {
-	d, err := newDailer(keyFiles, gatewayStr, gatewayProxyCommand)
+	d, err := newDialer(keyFiles, gatewayStr, gatewayProxyCommand)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- rename misnamed `dailer.go` to `dialer.go`
- update constructor function to `newDialer`
- adjust gateway to use `newDialer`

## Testing
- `go fmt dialer.go gateway.go`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6898b91d2f608324a11aefd6bc6e3a58