### PR TITLE
docs: correct config sample reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A tool helps to do ssh forwarding.
 
 ## Features
 
-* Usable as a CLI tool or as a library.
+- Usable as a CLI tool or as a library.
 
 ## Installation
 
@@ -45,9 +45,10 @@ GLOBAL OPTIONS:
    --version, -v             print the version (default: false)
 ```
 
-See [config.yaml.sample](cmd/tunnel/config.yml.sample) for format of config file.
+See [config.yml.sample](cmd/tunnel/config.yml.sample) for format of config file.
 
 ## Configuration File
+
 `tunnel` by default consults a few locations for the config files.
 
 1. specified in `--config` or `-c`


### PR DESCRIPTION
## Summary
- fix link text to point to the sample config `config.yml.sample`
- format README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898b93a740883249dbfaa33732295ee